### PR TITLE
Prefer pgcrypto to uuid-ossp

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Edit the migration
 ```ruby
 class EnableUuids < ActiveRecord::Migration
   def change
-    enable_extension 'uuid-ossp'
+    enable_extension 'pgcrypto'
   end
 end
 ```


### PR DESCRIPTION
https://www.postgresql.org/docs/devel/static/uuid-ossp.html#idm45580598808112
> Note
> If you only need randomly-generated (version 4) UUIDs, consider using the gen_random_uuid() function from the pgcrypto module instead.